### PR TITLE
pass state to callback module

### DIFF
--- a/lib/neutron/pulsar_consumer.ex
+++ b/lib/neutron/pulsar_consumer.ex
@@ -57,10 +57,11 @@ defmodule Neutron.PulsarConsumer do
     res =
       try do
         # todo investigate the bug that sometimes causes a unicode character from C library with pulsar
+        {config, _} = Map.split(state.config, [:subscription, :topic])
+
         callback_module.handle_message(
           String.trim_trailing(msg, "\a"),
-          state.config.topic,
-          state.config.subscription
+          config
         )
       catch
         _any -> {:error, :exception}

--- a/lib/neutron/pulsar_consumer.ex
+++ b/lib/neutron/pulsar_consumer.ex
@@ -59,8 +59,9 @@ defmodule Neutron.PulsarConsumer do
         # todo investigate the bug that sometimes causes a unicode character from C library with pulsar
         callback_module.handle_message(
           String.trim_trailing(msg, "\a"),
-          state
-        )      
+          state.config.topic,
+          state.config.subscription
+        )
       catch
         _any -> {:error, :exception}
       end

--- a/lib/neutron/pulsar_consumer.ex
+++ b/lib/neutron/pulsar_consumer.ex
@@ -57,7 +57,10 @@ defmodule Neutron.PulsarConsumer do
     res =
       try do
         # todo investigate the bug that sometimes causes a unicode character from C library with pulsar
-        callback_module.handle_message(String.trim_trailing(msg, "\a"))
+        callback_module.handle_message(
+          String.trim_trailing(msg, "\a"),
+          state
+        )      
       catch
         _any -> {:error, :exception}
       end

--- a/lib/neutron/pulsar_consumer_callback.ex
+++ b/lib/neutron/pulsar_consumer_callback.ex
@@ -1,4 +1,4 @@
 defmodule Neutron.PulsarConsumerCallback do
   @moduledoc "callback for consumers to implement for handling a message and whether to ack it"
-  @callback handle_message(String.t()) :: :ack | :ack_all | :nack
+  @callback handle_message(String.t(), any()) :: :ack | :ack_all | :nack
 end

--- a/lib/neutron/pulsar_consumer_callback.ex
+++ b/lib/neutron/pulsar_consumer_callback.ex
@@ -1,4 +1,4 @@
 defmodule Neutron.PulsarConsumerCallback do
   @moduledoc "callback for consumers to implement for handling a message and whether to ack it"
-  @callback handle_message(String.t(), String.t(), String.t()) :: :ack | :ack_all | :nack
+  @callback handle_message(String.t(), Map()) :: :ack | :ack_all | :nack
 end

--- a/lib/neutron/pulsar_consumer_callback.ex
+++ b/lib/neutron/pulsar_consumer_callback.ex
@@ -1,4 +1,4 @@
 defmodule Neutron.PulsarConsumerCallback do
   @moduledoc "callback for consumers to implement for handling a message and whether to ack it"
-  @callback handle_message(String.t(), any()) :: :ack | :ack_all | :nack
+  @callback handle_message(String.t(), String.t(), String.t()) :: :ack | :ack_all | :nack
 end


### PR DESCRIPTION
callback module was having issues running `:sys.get_state(self())` inside of genserver, passing the state can fix the problem. Probably should type the second arg instead of `any()`