### PR TITLE
allow naming of consumer processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,9 @@ $(warning MIX_APP_PATH not set. Invoke via mix)
 endif
 
 CPP_PATH=$(MIX_DEPS_PATH)/pulsar/pulsar-client-cpp
-PULSAR_VERSION=2.7.0
 
-ifeq ($(shell uname),Darwin)     # Mac OS X
-	PLATFORM_OPTIONS=-undefined dynamic_lookup -L/usr/local/Cellar/libpulsar/$(PULSAR_VERSION)/lib -lpulsar -rpath /usr/local/Cellar/libpulsar/$(PULSAR_VERSION)/lib
+ifeq ($(shell uname),Darwin) # Mac OS X
+	PLATFORM_OPTIONS=-undefined dynamic_lookup -L/usr/local/opt/libpulsar/lib -lpulsar -rpath /usr/local/opt/libpulsar/lib
 else
 	PLATFORM_OPTIONS=/usr/lib/libpulsar.so
 endif

--- a/build_deps.sh
+++ b/build_deps.sh
@@ -21,9 +21,11 @@ function DownloadLib()
     elif command -v brew &> /dev/null
     then
         echo "brew found"
-        LIBPULSAR_PATH=/usr/local/Cellar/libpulsar/${PULSAR_VERSION}/lib
+        LIBPULSAR_PATH=/usr/local/opt/libpulsar/lib
         if [[ -f "${LIBPULSAR_PATH}/libpulsar.a" ]]
         then
+            # TODO: may need to check for latest version
+            brew list --versions libpulsar
             echo "lib already downloaded"
             exit 0
         fi
@@ -45,7 +47,6 @@ function DownloadLib()
         exit 1
     fi
 }
-${PULSAR_VERSION}
 PULSAR_VERSION=2.7.0
 
 DownloadLib

--- a/lib/neutron/pulsar_consumer.ex
+++ b/lib/neutron/pulsar_consumer.ex
@@ -29,6 +29,7 @@ defmodule Neutron.PulsarConsumer do
     subscription = Keyword.get(arg, :subscription, "my-subscription")
     topic = Keyword.get(arg, :topic, "my-topic")
     consumer_type = Keyword.get(arg, :consumer_type, :shared)
+    name = Keyword.get(arg, :name, "PulsarConsumer-#{:erlang.unique_integer([:monotonic])}")
 
     if !is_binary(topic) || !is_binary(subscription) do
       raise "invalid arg given. Please pass-in a String.t()"
@@ -43,7 +44,7 @@ defmodule Neutron.PulsarConsumer do
         subscription: subscription,
         callback_module: callback_module,
         consumer_type: consumer_type
-      })
+      }), name: String.to_atom(name)
     )
   end
 


### PR DESCRIPTION
lets user send a name when creating a pulsar consumer

also has a fix for pulsar lib on mac to allow for brew's version increments 