### PR TITLE
Support for sending iodata to apache pulsar

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.11.1
+elixir 1.16.1

--- a/c_src/neutron_nif.c
+++ b/c_src/neutron_nif.c
@@ -667,7 +667,7 @@ sync_produce(ErlNifEnv * env, int argc,
 
   ErlNifBinary topic_bin;
 
-  int topic_ret = enif_inspect_binary(env, argv[1], & topic_bin);
+  int topic_ret = enif_inspect_iolist_as_binary(env, argv[1], & topic_bin);
   if (!topic_ret) {
     return make_error_tuple(env,
       "failed to create topic binary from input");
@@ -828,7 +828,7 @@ async_produce(ErlNifEnv * env, int argc,
 
   ErlNifBinary msg_bin;
 
-  int msg_ret = enif_inspect_binary(env, argv[1], & msg_bin);
+  int msg_ret = enif_inspect_iolist_as_binary(env, argv[1], & msg_bin);
   if (!msg_ret) {
     return make_error_tuple(env,
       "failed to create message binary from input");

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,7 +2,7 @@ import Config
 
 # Do not print debug/info messages in production
 config :logger,
-  level: :warn,
+  level: :warning,
   compile_time_purge_matching: [
-    [level_lower_than: :warn]
+    [level_lower_than: :warning]
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 import Config
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning

--- a/lib/neutron.ex
+++ b/lib/neutron.ex
@@ -147,4 +147,18 @@ defmodule Neutron do
              (is_tuple(producer_lookup) and is_binary(msg) and is_list(produce_opts)) do
     GenServer.call(producer_lookup, {:async_produce, msg, produce_opts |> Enum.into(%{})})
   end
+
+  @doc """
+  Does a asynchronous produce using the given producer pid generated from create_async_producer, given message and optional produce_opts.
+  message: It can be binary or iodata.
+  produce_opts: the keys are :deliver_after_ms and :deliver_at_ms both take an int as the value for :deliver_at_ms the int is a unix timestamp in milliseconds for :deliver_after_ms it's the delay to send the message after in milliseconds
+  Uses the global pulsar client for connection information.
+  Will return :ok on sucess or an {:error, String.t()} on failure
+  """
+  def async_iodata_produce!(producer_lookup, msg, produce_opts \\ [])
+    when is_pid(producer_lookup) or is_atom(producer_lookup) or
+    (is_tuple(producer_lookup) and is_list(produce_opts)) do
+      IO.iodata_length(msg) # It will raise an error if message is not a binary or iodata
+      GenServer.call(producer_lookup, {:async_produce, msg, produce_opts |> Enum.into(%{})})
+  end
 end

--- a/test/integration/neutron_test.exs
+++ b/test/integration/neutron_test.exs
@@ -16,11 +16,11 @@ defmodule NeutronTest do
   test "async produce is always successful" do
     defmodule DeliverCallback do
       @behaviour Neutron.PulsarAsyncProducerCallback
-      @compiled_pid self()
+      @compiled_pid :erlang.pid_to_list(self())
 
       @impl true
       def handle_delivery(res) do
-        _msg = send(@compiled_pid, {:test_deliver, res})
+        send(:erlang.list_to_pid(@compiled_pid), res)
       end
     end
 
@@ -37,7 +37,7 @@ defmodule NeutronTest do
   test "sync produce and consume roundtrip" do
     defmodule ConsumerCallback do
       @behaviour Neutron.PulsarConsumerCallback
-      @compiled_pid self()
+      @compiled_pid :erlang.pid_to_list(self())
 
       @impl true
       def handle_message(
@@ -46,7 +46,7 @@ defmodule NeutronTest do
             _state
           ) do
         send(
-          @compiled_pid,
+          :erlang.list_to_pid(@compiled_pid),
           {:test_callback, topic, partition_key, event_ts, properties, payload}
         )
 


### PR DESCRIPTION
Hola! 👋 

So after some work with neutron on production, we found out that messages are quite memory expensive to move around, so this change allow us to use [`iodata`](https://hexdocs.pm/elixir/IO.html#module-io-data) when pushing data to pulsar., improving the memory usage from our processes.

This change also introduce another elixir method to `Neutron` module, so there are no breaking changes as the current implementation for sending data async/sync is the same.

I ran the tests with `mix test.integrations` and I got a green build every time I ran it.